### PR TITLE
Max concurrency

### DIFF
--- a/xatlas.cpp
+++ b/xatlas.cpp
@@ -3235,7 +3235,7 @@ public:
 	}
 };
 
-const uint64_t defaultConcurrency = std::thread::hardware_concurrency() <= 1 ? 1 : std::thread::hardware_concurrency() - 1;
+const uint64_t maxConcurrency = std::thread::hardware_concurrency() <= 1 ? 1 : std::thread::hardware_concurrency() - 1;
 
 #if XA_MULTITHREADED
 class TaskScheduler
@@ -3260,9 +3260,10 @@ class TaskScheduler
 		TaskGroup(const TaskGroup&) = default;
 	};
 public:
-	TaskScheduler(uint64_t threadPoolSize = defaultConcurrency) : m_shutdown(false)
+	TaskScheduler(uint64_t threadPoolSize = maxConcurrency) : m_shutdown(false)
 	{
 		m_threadIndex = 0;
+		threadPoolSize = std::min(threadPoolSize, maxConcurrency);
 		m_workers.resize(threadPoolSize);
 		for (uint64_t i = 0; i < m_workers.size(); i++) {
 			new (&m_workers[i]) Worker();

--- a/xatlas.h
+++ b/xatlas.h
@@ -97,11 +97,11 @@ struct Atlas
 };
 
 namespace internal {
-extern const uint64_t defaultConcurrency;
+extern const uint64_t maxConcurrency;
 }
 
 // Create an empty atlas.
-Atlas *Create(uint64_t concurrency = internal::defaultConcurrency);
+Atlas *Create(uint64_t concurrency = internal::maxConcurrency);
 
 void Destroy(Atlas *atlas);
 


### PR DESCRIPTION
We observe XAtlas crash quite consistently when its concurrency is set above the default `num_cores - 1`.
At least running in GitHub Actions with 2 virtual cores.
We want to bound the concurrency to `num_cores - 1` to make it safer.