### PR TITLE
Build with C++23.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ set(XATLAS_HEADERS "xatlas.h")
 
 add_library(xatlas ${XATLAS_SRC} ${XATLAS_HEADERS})
 
+# cxx version
+set_target_properties(xatlas PROPERTIES
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+)
+
 target_include_directories(
     xatlas
     PUBLIC


### PR DESCRIPTION
The C++ version wasn't specified at all, so some compilers (VC++) will default to some ancient version of C++ without std::optional support. This wasn't a problem until recently because the tilers build was forcing C++23 on everything, including third-party libraries like this.
